### PR TITLE
Fixed build errors

### DIFF
--- a/components/bm8563/__init__.py
+++ b/components/bm8563/__init__.py
@@ -3,7 +3,8 @@ import esphome.config_validation as cv
 from esphome.components import i2c
 from esphome.const import CONF_ID, CONF_SLEEP_DURATION
 
-DEPENDENCIES = ['i2c']
+DEPENDENCIES = ('i2c',)
+AUTO_LOAD = ('sensor',)
 
 CONF_I2C_ADDR = 0x51
 

--- a/components/bm8563/bm8563.cpp
+++ b/components/bm8563/bm8563.cpp
@@ -1,5 +1,5 @@
-#include "esphome/core/log.h"
-#include "esphome/components/i2c/i2c_bus.h"
+#include <esphome/core/log.h>
+#include <esphome/components/i2c/i2c_bus.h>
 #include "bm8563.h"
 
 namespace esphome {

--- a/components/bm8563/bm8563.h
+++ b/components/bm8563/bm8563.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/components/sensor/sensor.h"
-#include "esphome/components/i2c/i2c.h"
+#include <esphome/core/component.h>
+#include <esphome/components/sensor/sensor.h>
+#include <esphome/components/i2c/i2c.h>
 
 
 namespace esphome {


### PR DESCRIPTION
```c
In file included from src/esphome/components/bm8563/bm8563.cpp:3:
src/esphome/components/bm8563/bm8563.h:4:10: fatal error: esphome/components/sensor/sensor.h: No such file or directory
 #include "esphome/components/sensor/sensor.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```